### PR TITLE
Upgrade Bundler to resolve CVE-2020-36327

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,6 @@
 FROM ruby:2.5
 
+ENV BUNDLER_VERSION 2.2.18
 RUN mkdir /src
 WORKDIR /src
 
@@ -7,7 +8,7 @@ COPY expiring_memoize.gemspec /src
 COPY Gemfile /src
 COPY lib/expiring_memoize/version.rb /src/lib/expiring_memoize/
 
-RUN bundle install
+RUN gem install bundler:$BUNDLER_VERSION && bundle install
 
 COPY . /src/
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
 
     // Only publish to RubyGems if branch is 'master'
     stage('Publish to RubyGems?') {
-      agent { label 'releaser-v2' }
+      agent { label 'executor-v2' }
 
       when {
         branch 'master'

--- a/expiring_memoize.gemspec
+++ b/expiring_memoize.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", "~> 2.2.18"
   spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Upgrades Bundler to 2.2.18 to resolve CVE-2020-36327

### What ticket does this PR close?
Resolves #2

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation
